### PR TITLE
Add plantuml

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,3 +15,14 @@ For full documentation visit [mkdocs.org](https://www.mkdocs.org).
     docs/
         index.md  # The documentation homepage.
         ...       # Other markdown pages, images and other files.
+
+## Diagrams
+
+```plantuml
+title Sample PlantUML Diagram
+header Sample Project
+footer Sample Project
+
+Sender -> Receiver
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ title Sample PlantUML Diagram
 header Sample Project
 footer Sample Project
 
-Sender -> Receiver
+Sender ->  Receiver: Request
+Sender <-- Receiver: Response
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,4 @@
 site_name: My Docs
+markdown_extensions:
+  - plantuml_markdown:
+      server: http://www.plantuml.com/plantuml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,4 +2,4 @@ site_name: My Docs
 markdown_extensions:
   - plantuml_markdown:
       # trailing slash omitted deliberately
-      server: http://plantuml-server:8080
+      server: !ENV [PLANTUML_SERVER_URL, 'http://www.plantuml.com/plantuml']

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: My Docs
 markdown_extensions:
   - plantuml_markdown:
-      server: http://www.plantuml.com/plantuml
+      # trailing slash omitted deliberately
+      server: http://plantuml-server:8080

--- a/tools/mkdocs-serve
+++ b/tools/mkdocs-serve
@@ -1,0 +1,3 @@
+#! /bin/sh
+mkdocs serve --dev-addr 0.0.0.0:8000 --verbose
+

--- a/utils/docker-compose.yml
+++ b/utils/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build: .
     command: pause
     hostname: devcontainer
+    environment:
+      - PLANTUML_SERVER_URL=http://plantuml-server:8080 # no trailing slash
     ports:
       - target: 8000
         published: 8000

--- a/utils/docker-compose.yml
+++ b/utils/docker-compose.yml
@@ -15,5 +15,7 @@ services:
       - type: bind
         source: /var/run/docker.sock
         target: /var/run/docker.sock
+  plantuml-server:
+    image: plantuml/plantuml-server
 volumes:
   local-data:

--- a/utils/install
+++ b/utils/install
@@ -32,6 +32,7 @@ dnf -q -y install docker-ce-cli docker-compose-plugin
 echo "Installing python3 and mkdocs"
 dnf -q -y install python39
 pip3 install mkdocs
+pip3 install plantuml-markdown
 
 echo "Installing other utilities on PATH"
 ln -s $SOURCE_DIR/bin/* /usr/local/bin/


### PR DESCRIPTION
Add plantuml to project.

- mkdocs uses configurable plantuml server to generate diagrams
- docker-compose file provides local plantuml server