### PR TITLE
Add mkdocs to pdf

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ For full documentation visit [mkdocs.org](https://www.mkdocs.org).
 
 ## Diagrams
 
-```plantuml
+```plantuml width="100%"
 title Sample PlantUML Diagram
 header Sample Project
 footer Sample Project

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,3 +7,9 @@ markdown_extensions:
   - plantuml_markdown:
       # trailing slash omitted deliberately
       server: !ENV [PLANTUML_SERVER_URL, 'http://www.plantuml.com/plantuml']
+      # set the format
+      # Options:
+      #   png:        Fuzzy images when scaled up
+      #   svg:        Non-fuzzy images, no text highlighting on web
+      #   svg_inline: Non-fuzzy images, text highlighting on web but broken render to PDF
+      format: svg

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,9 @@
 site_name: My Docs
+plugins:
+  - search
+  - with-pdf
 markdown_extensions:
+  - toc
   - plantuml_markdown:
       # trailing slash omitted deliberately
       server: !ENV [PLANTUML_SERVER_URL, 'http://www.plantuml.com/plantuml']

--- a/utils/docker-compose.yml
+++ b/utils/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.2"
 services:
   devcontainer:
     build: .

--- a/utils/install
+++ b/utils/install
@@ -34,6 +34,12 @@ dnf -q -y install python39
 pip3 install mkdocs
 pip3 install plantuml-markdown
 
+echo "Installing mkdocs to PDF"
+dnf -q -y install pango
+echo -e "\tUsing weasyprint<53 for compat with pango 1.42.3, which is latest on almalinux as of 2022-11-27"
+pip3 install 'weasyprint<53'
+pip3 install mkdocs-with-pdf
+
 echo "Installing other utilities on PATH"
 ln -s $SOURCE_DIR/bin/* /usr/local/bin/
 


### PR DESCRIPTION
Automatically exports all documentation to PDF on build.

When `tools/mkdocs-serve` is run, the produced PDF is available at `/pdf/document.pdf`.

Changes:
- Adds `mkdocs-with-pdf` and related dependencies

Other Changes:
- set compose file version to 3.2 to work with other `docker` versions
- Change plantuml output to svg from default pdf to avoid fuzzy images