### PR TITLE
Migrate devcontainer to fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Sample Project comes with a dedicated development environment powered by Doc
 ### Requirements
 
 The following applications are required to host the development environment:
-- Docker (with compose extension)
+- Docker >= 20.10.10 (with compose extension)
 - Git, or a curl-equivalent
 
 ### Instructions

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Sample Project comes with a dedicated development environment powered by Doc
 ### Requirements
 
 The following applications are required to host the development environment:
-- Docker >= 20.10.10 (with compose extension)
+- Docker with compose extension (>=20.10.10; see https://github.com/moby/moby/issues/42680)
 - Git, or a curl-equivalent
 
 ### Instructions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,9 +7,4 @@ markdown_extensions:
   - plantuml_markdown:
       # trailing slash omitted deliberately
       server: !ENV [PLANTUML_SERVER_URL, 'http://www.plantuml.com/plantuml']
-      # set the format
-      # Options:
-      #   png:        Fuzzy images when scaled up
-      #   svg:        Non-fuzzy images, no text highlighting on web
-      #   svg_inline: Non-fuzzy images, text highlighting on web but broken render to PDF
-      format: svg
+      format: svg_inline

--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux
+FROM fedora:latest
 COPY ./ /usr/local/src/devcontainer
 WORKDIR /usr/local/src/devcontainer
 RUN /usr/local/src/devcontainer/install

--- a/utils/install
+++ b/utils/install
@@ -19,25 +19,25 @@ PS1='[\\u@\\h \\W\$(__git_ps1 " (%s)")]\\$ '
 EOF
 
 echo "Installing x11 utilities"
-dnf -q -y install           \
-    xorg-x11-server-utils   \
-    xorg-x11-server-Xorg    \
-    xorg-x11-xauth
+dnf -q -y install        \
+    xclock               \
+    xorg-x11-server-Xorg \
+    xorg-x11-xauth       \
+    xset
 
 echo "Installing Docker"
 dnf -q -y install 'dnf-command(config-manager)'
-dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
 dnf -q -y install docker-ce-cli docker-compose-plugin
 
 echo "Installing python3 and mkdocs"
-dnf -q -y install python39
+dnf -q -y install python3 python3-pip
 pip3 install mkdocs
 pip3 install plantuml-markdown
 
 echo "Installing mkdocs to PDF"
 dnf -q -y install pango
-echo -e "\tUsing weasyprint<53 for compat with pango 1.42.3, which is latest on almalinux as of 2022-11-27"
-pip3 install 'weasyprint<53'
+pip3 install weasyprint
 pip3 install mkdocs-with-pdf
 
 echo "Installing other utilities on PATH"


### PR DESCRIPTION
Use fedora instead of almalinux for the devbox.

Changes:
- Use `fedora:latest`
- Use latest `weasyprint` now that `pango v1.44` is available
- Use `svg_inline` in mkdocs for inline text in both site and pdf now that `weasyprint v53` is available
- Add note on v20.10.10 minimum Docker version