### PR TITLE
Add terminator to dev image

### DIFF
--- a/utils/entrypoint
+++ b/utils/entrypoint
@@ -41,15 +41,13 @@ pause_forever()
 transfer_control_to_shell()
 {
     if xset -q >/dev/null 2>&1
-    then
-        echo "Info: GUI applications are enabled."
-        echo
+    then terminator
     else
         echo "Warning: GUI applications are not enabled."
         echo -e "\tConfigure your DISPLAY variable to enable GUI applications."
         echo
+        /bin/bash
     fi
-    /bin/bash
 }
 
 print_error_and_exit()

--- a/utils/install
+++ b/utils/install
@@ -7,7 +7,12 @@ echo "Installing"
 dnf -q -y update
 
 echo "Installing common tools"
-dnf -q -y install which
+dnf -q -y install \
+    boxes         \
+    cowsay        \
+    figlet        \
+    lolcat        \
+    which
 
 echo "Installing git"
 dnf -q -y install git
@@ -24,6 +29,9 @@ dnf -q -y install        \
     xorg-x11-server-Xorg \
     xorg-x11-xauth       \
     xset
+
+echo "Installing terminal emulator"
+dnf -q -y install terminator
 
 echo "Installing Docker"
 dnf -q -y install 'dnf-command(config-manager)'


### PR DESCRIPTION
On entrypoint startup, if an X11 server is available, `terminator` will be started instead of passing control to bash.

A few other fun utilities are added.