### PR TITLE
Use dind for kind

### DIFF
--- a/tools/kindconfig.yaml
+++ b/tools/kindconfig.yaml
@@ -7,4 +7,4 @@ kubeadmConfigPatches:
     kind: ClusterConfiguration
     apiServer:
       certSANs:
-        - "docker"
+        - "$DOCKER_PUBLIC_ADDRESS" # you will have to change this

--- a/tools/kindconfig.yaml
+++ b/tools/kindconfig.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: 0.0.0.0
+kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      certSANs:
+        - "docker"

--- a/tools/post-kind
+++ b/tools/post-kind
@@ -1,3 +1,3 @@
 #! /bin/sh
-sed -i 's/0.0.0.0/docker/' ~/.kube/config
+sed -i "s/0.0.0.0/$DOCKER_PUBLIC_ADDRESS/" ~/.kube/config
 

--- a/tools/post-kind
+++ b/tools/post-kind
@@ -1,27 +1,3 @@
 #! /bin/sh
-if kubectl get nodes >/dev/null 2>&1
-then exit 0
-fi
-
-# get the first network name that we are connected to
-MY_CONTAINER_ID="$(cat /etc/hostname)"
-docker inspect $MY_CONTAINER_ID >/dev/null
-MY_NETWORK_NAME="$(docker inspect "$MY_CONTAINER_ID" -f '{{range $key, $value := .NetworkSettings.Networks}}{{$key}}{{"\n"}}{{end}}' | head -n 1)"
-
-# get the public server URL from the kubeconfig
-CURRENT_CONTEXT="$(kubectl config current-context)"
-CURRENT_CLUSTER="$(kubectl config view -o "jsonpath={.contexts[?(@.name=='$CURRENT_CONTEXT')].context.cluster}")"
-CURRENT_SERVER="$(kubectl config view -o "jsonpath={.clusters[?(@.name=='$CURRENT_CLUSTER')].cluster.server}")"
-# get container port from the public server URL of the form 'https://127.0.0.1:$CONTAINER_PORT'
-KIND_CONTAINER_PORT="$(echo "$CURRENT_SERVER" | sed 's|https://127.0.0.1:||')"
-# get container ID from open TCP port
-KIND_CONTAINER_ID="$(docker ps --filter "publish=$KIND_CONTAINER_PORT/tcp" --format '{{.ID}}')"
-# get container name from ID, removing leading '/' that Docker likes to prepend
-KIND_CONTAINER_NAME="$(docker inspect "$KIND_CONTAINER_ID" -f '{{.Name}}' | sed 's|^/||')"
-
-# connect the container to our network by name
-docker network connect "$MY_NETWORK_NAME" "$KIND_CONTAINER_NAME"
-# update the kubeconfig file with the correct server
-kubectl config set-cluster "$CURRENT_CLUSTER" "--server=https://$KIND_CONTAINER_NAME:6443"
-
+sed -i 's/0.0.0.0/docker/' ~/.kube/config
 

--- a/utils/docker-compose.yml
+++ b/utils/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     command: pause
     environment:
       - PLANTUML_SERVER_URL=http://plantuml-server:8080
+      - DOCKER_PUBLIC_ADDRESS=docker
       - DOCKER_HOST=tcp://docker:2376
       - DOCKER_TLS_VERIFY=1
       - DOCKER_CERT_PATH=/etc/docker/certs/client

--- a/utils/docker-compose.yml
+++ b/utils/docker-compose.yml
@@ -4,7 +4,10 @@ services:
     build: .
     command: pause
     environment:
-      - PLANTUML_SERVER_URL=http://plantuml-server:8080 # no trailing slash
+      - PLANTUML_SERVER_URL=http://plantuml-server:8080
+      - DOCKER_HOST=tcp://docker:2376
+      - DOCKER_TLS_VERIFY=1
+      - DOCKER_CERT_PATH=/etc/docker/certs/client
     ports:
       - target: 8000
         published: 8000
@@ -14,10 +17,24 @@ services:
       - type: volume
         source: local-data
         target: /root
-      - type: bind
-        source: /var/run/docker.sock
-        target: /var/run/docker.sock
+      - type: volume
+        source: docker-certs
+        target: /etc/docker/certs
+        read_only: true
   plantuml-server:
     image: plantuml/plantuml-server
+  docker:
+    image: docker:dind
+    privileged: true
+    volumes:
+      - type: volume
+        source: docker-certs
+        target: /certs
+    ports:
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
 volumes:
   local-data:
+  docker-certs:


### PR DESCRIPTION
This PR replaces tooling for starting kind as a "sibling" container with tooling for starting kind as a "nibling" container.

Details:
- A container running `docker:dind` provides a docker socket over TCP and should be indistinguishable from a full remote docker host
- The docker cert for `docker:dind` is mounted into the devcontainer using a shared volume
- kind is started on this container remotely. It binds to `0.0.0.0` for public access instead of `127.0.0.1`; see security notes below.
- The domain name of the dind container is provided via env vars to the devcontainer in `DOCKER_PUBLIC_ADDRESS`. This is used to 'correct' the kubernetes API server address in kubeconfig after kind generates it for `0.0.0.0`.

Security notes:
- kind's Security Goose advises against exposing a kind cluster outside of its host machine. We are exposing the kind cluster outside of its host container (dind) so the development environment has access to this, which could in theory give root access to the host system due to `docker:dind` having privileged mode. However since this is all done within a docker network local to the host this should not pose any security risks.