### PR TITLE
Install bash-completion

### DIFF
--- a/devtools/install
+++ b/devtools/install
@@ -29,9 +29,11 @@ dnf -q -y install        \
 echo "Installing terminal emulator"
 dnf -q -y install terminator
 
+echo "Installing bash-completion"
+dnf -q -y install bash-completion
+
 echo "Installing git"
 dnf -q -y install git
-ln -s /usr/share/bash-completion/completions/git /etc/profile.d/git-completion.sh
 cat > /etc/profile.d/git-profile.sh <<EOF
 GIT_PS1_SHOWDIRTYSTATE=1
 . /usr/share/git-core/contrib/completion/git-prompt.sh
@@ -56,20 +58,20 @@ pip3 install mkdocs-with-pdf
 echo "Installing kubernetes utilities: kubectl"
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-echo "source <(kubectl completion bash)" > /etc/profile.d/kubectl-completion.sh
+echo "source <(kubectl completion bash)" > /usr/share/bash-completion/completions/kubectl # yes, /usr/share instead of /usr/local/share
 
 echo "Installing kubernetes utilities: kind"
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
-echo "source <(kind completion bash)" > /etc/profile.d/kind-completion.sh
+echo "source <(kind completion bash)" > /usr/share/bash-completion/completions/kind # yes, /usr/share instead of /usr/local/share
 
 echo "Installing kubernetes utilities: helm"
 curl -Lo ./helm.tar.gz https://get.helm.sh/helm-v3.10.2-linux-amd64.tar.gz
 tar -zxvf helm.tar.gz
 mv linux-amd64/helm /usr/local/bin/helm
 rm -rf linux-amd64 helm.tar.gz
-echo "source <(helm completion bash)" > /etc/profile.d/helm-completion.sh
+echo "source <(helm completion bash)" > /usr/share/bash-completion/completions/helm # yes, /usr/share instead of /usr/local/share
 
 echo "Installing kubernetes utilities: k9s"
 curl -Lo ./k9s.tar.gz https://github.com/derailed/k9s/releases/download/v0.27.3/k9s_linux_amd64.tar.gz


### PR DESCRIPTION
Adds bash-completion.

kind, helm, and kubectl completion scripts are put in `/usr/share/` instead of `~/.share` to keep them out of the root volume.