### PR TITLE
Add correct namespace

### DIFF
--- a/tools/ingress-down
+++ b/tools/ingress-down
@@ -2,5 +2,5 @@
 set -e
 
 # teardown ingress
-helm uninstall ingress-nginx
+helm uninstall ingress-nginx --namespace ingress-nginx
 


### PR DESCRIPTION
`tools/ingress-down` now uses the correct namespace instead of the default