### PR TITLE
Fix terminator fdwalk seccomp issue

### DIFF
--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -26,6 +26,8 @@ services:
         source: docker-certs
         target: /etc/docker/certs
         read_only: true
+    security_opt:
+      - seccomp:unconfined
   plantuml-server:
     image: plantuml/plantuml-server
   docker:

--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -26,6 +26,9 @@ services:
         source: docker-certs
         target: /etc/docker/certs
         read_only: true
+    # on some linux systems, terminator cannot start /bin/bash because of a system call to fdwalk
+    # that raises a seccomp issue similar to https://github.com/mviereck/x11docker/issues/346
+    # this doesn't seem to happen on Docker Desktop (windows)
     security_opt:
       - seccomp:unconfined
   plantuml-server:


### PR DESCRIPTION
This PR resolves an issue where `terminator` would fail to start with an error relating to `fdwalk` on a non-Docker Desktop (windows) system.

Security Considerations:
- `devcontainer` already has access to `docker:dind` image running in privileged mode. Therefore it already had effective root access to host system. No additional risk taken.